### PR TITLE
feat(agent-factory): fix-feedback workflow for numbered follow-up requests

### DIFF
--- a/.github/workflows/kibana-agent-fix-feedback.lock.yml
+++ b/.github/workflows/kibana-agent-fix-feedback.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"3f3d0f467c22739d9cfc21ce8461a8132cbbd3b6013a6d19aa6561886d9ada14","compiler_version":"v0.71.1","strict":true,"agent_id":"claude","agent_model":"llm-gateway/claude-opus-4-6"}
-# gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"239aec45b78c8799417efdd5bc6d8cc036629ec1","version":"v0.71.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28","digest":"sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28@sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28","digest":"sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28@sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28","digest":"sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28@sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.0"},{"image":"ghcr.io/github/github-mcp-server:v1.0.2"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"9926bb660545069dd0b4aff4f6866ba4e2fe8f3b38d7114e001ff1dcc21ece98","compiler_version":"v0.71.1","strict":true,"agent_id":"claude","agent_model":"llm-gateway/claude-opus-4-6"}
+# gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"239aec45b78c8799417efdd5bc6d8cc036629ec1","version":"v0.71.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28","digest":"sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28@sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28","digest":"sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28@sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28","digest":"sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28@sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.0"},{"image":"ghcr.io/github/github-mcp-server:v1.0.2"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -22,7 +22,7 @@
 #
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
-# POC stub — respond to review or bot feedback on a PR (scaffold only).
+# Apply targeted fixes on a draft PR in response to numbered review findings from kibana-agent.
 #
 # Resolved workflow manifest:
 #   Imports:
@@ -38,6 +38,7 @@
 #
 # Secrets used:
 #   - ANTHROPIC_API_KEY
+#   - GH_AW_CI_TRIGGER_TOKEN
 #   - GH_AW_GITHUB_MCP_SERVER_TOKEN
 #   - GH_AW_GITHUB_TOKEN
 #   - GITHUB_TOKEN
@@ -60,7 +61,7 @@
 
 name: "Kibana Agent Fix Feedback"
 "on":
-  pull_request_review_comment:
+  issue_comment:
     types:
     - created
   workflow_dispatch:
@@ -74,8 +75,7 @@ name: "Kibana Agent Fix Feedback"
 permissions: {}
 
 concurrency:
-  group: "gh-aw-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}"
-  cancel-in-progress: true
+  group: "gh-aw-${{ github.workflow }}-${{ github.event.issue.number || github.run_id }}"
 
 run-name: "Kibana Agent Fix Feedback"
 
@@ -208,16 +208,19 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_c8de90e7f9837b27_EOF'
+          cat << 'GH_AW_PROMPT_726e3c45ffcab570_EOF'
           <system>
-          GH_AW_PROMPT_c8de90e7f9837b27_EOF
+          GH_AW_PROMPT_726e3c45ffcab570_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_c8de90e7f9837b27_EOF'
+          cat << 'GH_AW_PROMPT_726e3c45ffcab570_EOF'
           <safe-output-tools>
-          Tools: add_comment, missing_tool, missing_data, noop
+          Tools: add_comment(max:2), push_to_pull_request_branch, missing_tool, missing_data, noop
+          GH_AW_PROMPT_726e3c45ffcab570_EOF
+          cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_push_to_pr_branch.md"
+          cat << 'GH_AW_PROMPT_726e3c45ffcab570_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -247,12 +250,15 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_c8de90e7f9837b27_EOF
+          GH_AW_PROMPT_726e3c45ffcab570_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_c8de90e7f9837b27_EOF'
+          if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
+            cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_push_to_pr_branch_guidance.md"
+          fi
+          cat << 'GH_AW_PROMPT_726e3c45ffcab570_EOF'
           </system>
           {{#runtime-import .github/aw/kibana-agent/imports/common.md}}
           {{#runtime-import .github/aw/kibana-agent/imports/trusted-user-gating.md}}
@@ -264,7 +270,7 @@ jobs:
           {{#runtime-import .github/aw/kibana-agent/imports/safe-outputs-pr.md}}
           {{#runtime-import .github/aw/kibana-agent/imports/safe-outputs-comment.md}}
           {{#runtime-import .github/workflows/kibana-agent-fix-feedback.md}}
-          GH_AW_PROMPT_c8de90e7f9837b27_EOF
+          GH_AW_PROMPT_726e3c45ffcab570_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -451,15 +457,16 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_237e6960e0f8ae25_EOF'
-          {"add_comment":{"hide_older_comments":true,"max":1,"target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_237e6960e0f8ae25_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_d96301eb95160c81_EOF'
+          {"add_comment":{"hide_older_comments":false,"max":2,"target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_to_pull_request_branch":{"if_no_changes":"warn","max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","CLAUDE.md","AGENTS.md"],"protected_path_prefixes":[".github/",".agents/",".githooks/",".husky/",".claude/"],"target":"triggering"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_d96301eb95160c81_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added. Target: *. Supports reply_to_id for discussion threading."
+                "add_comment": " CONSTRAINTS: Maximum 2 comment(s) can be added. Target: *. Supports reply_to_id for discussion threading.",
+                "push_to_pull_request_branch": " CONSTRAINTS: Maximum 1 push(es) can be made."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -542,6 +549,26 @@ jobs:
                     "type": "string",
                     "sanitize": true,
                     "maxLength": 65000
+                  }
+                }
+              },
+              "push_to_pull_request_branch": {
+                "defaultMax": 1,
+                "fields": {
+                  "branch": {
+                    "required": true,
+                    "type": "string",
+                    "sanitize": true,
+                    "maxLength": 256
+                  },
+                  "message": {
+                    "required": true,
+                    "type": "string",
+                    "sanitize": true,
+                    "maxLength": 65000
+                  },
+                  "pull_request_number": {
+                    "issueOrPRNumber": true
                   }
                 }
               },
@@ -640,7 +667,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.0'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_c7a19d4fc87aba2a_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_ce5076f95c4b9be0_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -680,7 +707,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_c7a19d4fc87aba2a_EOF
+          GH_AW_MCP_CONFIG_ce5076f95c4b9be0_EOF
       - name: Clean git credentials
         continue-on-error: true
         run: bash "${RUNNER_TEMP}/gh-aw/actions/clean_git_credentials.sh"
@@ -756,7 +783,7 @@ jobs:
         # - mcp__github__search_repositories
         # - mcp__github__search_users
         # - mcp__safeoutputs
-        timeout-minutes: 20
+        timeout-minutes: 45
         run: |
           set -o pipefail
           touch /tmp/gh-aw/agent-step-summary.md
@@ -933,7 +960,7 @@ jobs:
       needs.activation.outputs.stale_lock_file_failed == 'true')
     runs-on: ubuntu-slim
     permissions:
-      contents: read
+      contents: write
       discussions: write
       issues: write
       pull-requests: write
@@ -1042,12 +1069,14 @@ jobs:
           GH_AW_ENGINE_ID: "claude"
           GH_AW_SECRET_VERIFICATION_RESULT: ${{ needs.activation.outputs.secret_verification_result }}
           GH_AW_CHECKOUT_PR_SUCCESS: ${{ needs.agent.outputs.checkout_pr_success }}
+          GH_AW_CODE_PUSH_FAILURE_ERRORS: ${{ needs.safe_outputs.outputs.code_push_failure_errors }}
+          GH_AW_CODE_PUSH_FAILURE_COUNT: ${{ needs.safe_outputs.outputs.code_push_failure_count }}
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
           GH_AW_STALE_LOCK_FILE_FAILED: ${{ needs.activation.outputs.stale_lock_file_failed }}
           GH_AW_SAFE_OUTPUT_MESSAGES: "{\"activationComments\":\"false\"}"
           GH_AW_GROUP_REPORTS: "false"
           GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
-          GH_AW_TIMEOUT_MINUTES: "20"
+          GH_AW_TIMEOUT_MINUTES: "45"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -1142,7 +1171,7 @@ jobs:
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
           WORKFLOW_NAME: "Kibana Agent Fix Feedback"
-          WORKFLOW_DESCRIPTION: "POC stub — respond to review or bot feedback on a PR (scaffold only)."
+          WORKFLOW_DESCRIPTION: "Apply targeted fixes on a draft PR in response to numbered review findings from kibana-agent."
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |
@@ -1263,7 +1292,7 @@ jobs:
     if: (!cancelled()) && needs.agent.result != 'skipped' && needs.detection.result == 'success'
     runs-on: ubuntu-slim
     permissions:
-      contents: read
+      contents: write
       discussions: write
       issues: write
       pull-requests: write
@@ -1288,6 +1317,8 @@ jobs:
       create_discussion_errors: ${{ steps.process_safe_outputs.outputs.create_discussion_errors }}
       process_safe_outputs_processed_count: ${{ steps.process_safe_outputs.outputs.processed_count }}
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
+      push_commit_sha: ${{ steps.process_safe_outputs.outputs.push_commit_sha }}
+      push_commit_url: ${{ steps.process_safe_outputs.outputs.push_commit_url }}
     steps:
       - name: Setup Scripts
         id: setup
@@ -1310,6 +1341,34 @@ jobs:
           mkdir -p /tmp/gh-aw/
           find "/tmp/gh-aw/" -type f -print
           echo "GH_AW_AGENT_OUTPUT=/tmp/gh-aw/agent_output.json" >> "$GITHUB_OUTPUT"
+      - name: Download patch artifact
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: agent
+          path: /tmp/gh-aw/
+      - name: Checkout repository
+        if: (!cancelled()) && needs.agent.result != 'skipped' && contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch')
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.base_ref || github.event.pull_request.base.ref || github.ref_name || github.event.repository.default_branch }}
+          token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          persist-credentials: false
+          fetch-depth: 1
+      - name: Configure Git credentials
+        if: (!cancelled()) && needs.agent.result != 'skipped' && contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch')
+        env:
+          REPO_NAME: ${{ github.repository }}
+          SERVER_URL: ${{ github.server_url }}
+          GIT_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git config --global am.keepcr true
+          # Re-authenticate git with GitHub token
+          SERVER_URL_STRIPPED="${SERVER_URL#https://}"
+          git remote set-url origin "https://x-access-token:${GIT_TOKEN}@${SERVER_URL_STRIPPED}/${REPO_NAME}.git"
+          echo "Git configured with standard GitHub Actions identity"
       - name: Configure GH_HOST for enterprise compatibility
         id: ghes-host-config
         shell: bash
@@ -1327,7 +1386,8 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.buildkite.com,*.elastic.co,*.elastic.dev,*.githubusercontent.com,anthropic.com,api.anthropic.com,api.github.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,buildkite.com,cdn.playwright.dev,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,elastic.co,elastic.dev,elastic.litellm-prod.ai,files.pythonhosted.org,ghcr.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,playwright.download.prss.microsoft.com,ppa.launchpad.net,pypi.org,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,sentry.io,statsig.anthropic.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":1,\"target\":\"*\"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":false,\"max\":2,\"target\":\"*\"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"push_to_pull_request_branch\":{\"if_no_changes\":\"warn\",\"max\":1,\"max_patch_size\":1024,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"CLAUDE.md\",\"AGENTS.md\"],\"protected_path_prefixes\":[\".github/\",\".agents/\",\".githooks/\",\".husky/\",\".claude/\"],\"target\":\"triggering\"},\"report_incomplete\":{}}"
+          GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/kibana-agent-fix-feedback.md
+++ b/.github/workflows/kibana-agent-fix-feedback.md
@@ -1,9 +1,9 @@
 ---
 name: Kibana Agent Fix Feedback
-description: POC stub — respond to review or bot feedback on a PR (scaffold only).
+description: Apply targeted fixes on a draft PR in response to numbered review findings from kibana-agent.
 on:
   workflow_dispatch:
-  pull_request_review_comment:
+  issue_comment:
     types: [created]
 
 permissions:
@@ -45,15 +45,126 @@ safe-outputs:
   report-failure-as-issue: false
   threat-detection:
     enabled: true
-  add-comment:
+  push-to-pull-request-branch:
+    target: "triggering"
     max: 1
+  add-comment:
+    max: 2
     target: "*"
-    hide-older-comments: true
+    hide-older-comments: false
 
 strict: true
-timeout-minutes: 20
+timeout-minutes: 45
 ---
 
-# Kibana Agent — fix feedback (POC stub)
+# Kibana Agent — fix feedback
 
-Placeholder for addressing inline review feedback via safe outputs.
+## 1. Identity and scope
+
+You are **kibana-agent**, working on a **pull request** in the Kibana monorepo. A trusted collaborator invoked you from a **PR comment** to address one or more **numbered findings** from your own prior **synthesized review** on that PR.
+
+You implement **targeted code changes** on the PR head branch, push via **`push_to_pull_request_branch`**, and post a **short confirmation** via **`add_comment`**.
+
+Activation already enforces **repository roles** with **write or higher** (`write`, `maintain`, or `admin`). Treat the triggering actor as trusted for this run.
+
+If this run was started with **`workflow_dispatch`** instead of a thread comment, treat the inputs (including any **`aw_context`** payload from Agentic Workflows) as the source for **PR identification** and the **`fix`** subcommand. If that context does not specify a PR and a supported `fix` form, call **`missing_data`** (or **`report_incomplete`**) instead of guessing.
+
+## 2. Trigger parsing and silent exits
+
+Read the **triggering comment** body from GitHub event / activation context.
+
+**Supported forms** (handle is case-insensitive; allow arbitrary whitespace between tokens):
+
+- `@kibana-agent fix <N>` or `@kibana-agent fix #<N>` where `N` is a positive integer — fix finding **N** only.
+- `@kibana-agent fix all` — fix **every** remaining numbered item under **`### Findings`** from the authoritative review (see warning below).
+
+If **any** of the following holds, call **`noop`** and stop — do **not** call **`add_comment`**, **`push_to_pull_request_branch`**, or any other write safe output:
+
+- The event is **not** a **pull request** thread comment (e.g. a plain issue with no linked PR).
+- The body does **not** match one of the supported forms above (including incidental mentions of “fix” that are not this command).
+
+
+## 3. Authoritative review comment
+
+1. Resolve the **PR number** from the triggering context (for `issue_comment`, the issue number **is** the PR number when the issue is a PR).
+2. Fetch **PR review / issue comments** and locate the **latest** top-level comment that:
+   - Contains a **`### Findings`** section, and
+   - Matches the **review template** produced by the kibana-agent review workflow (e.g. a `## Review —` heading and structured summary / auto-fixed / findings / verdict sections), and
+   - Is authored by the **same GitHub identity** kibana-agent uses for review posts (the bot or app account that publishes synthesized reviews).
+3. If **no** such comment exists, post **one** **`add_comment`** explaining that no numbered review findings were found, then stop.
+
+### Parsing findings
+
+Under **`### Findings`**, each line should look like:
+
+`N. **[Category]** … — optional backtick path:line refs`
+
+Extract for the requested number(s):
+
+- **Index** `N`
+- **Category** (e.g. Scope, Quality, Conventions, coverage-related labels)
+- **Full description**
+- **File and line references** when present
+
+If the user asked for **`fix <N>`** and **N** is missing or not an integer item in that list, post **one** **`add_comment`** stating the finding was not found, then stop.
+
+## 4. `fix all` — scope and warning
+
+All items under **`### Findings`** are **decision-tier** (they were intentionally left for human judgment in the review). **`fix all`** asks you to **attempt** each remaining finding in **one** pass.
+
+Before substantive edits, post **one** **`add_comment`** that:
+
+- States you are processing **all** listed findings in this review comment,
+- Warns that this may produce **broad or conflicting** edits and that humans should still review the result.
+
+Then proceed to implement across findings in **number order**, merging conflicts in approach as needed.
+
+If **`fix <N>`** (single finding), **skip** this warning comment unless you need to surface a blocker early (use the second allowed comment for errors or completion as needed).
+
+## 5. When **not** to patch
+
+If a finding **requires fundamental design or product decisions** (API shape, security model, major architecture, ambiguous behavior), **do not** guess and **do not** land a large speculative refactor.
+
+Instead, post **`add_comment`** explaining that finding **N** needs **human discussion**, briefly why, and stop **without** pushing for that finding (for `fix all`, **skip** that item and **continue** others if you can do so safely; if nothing is safe to change, explain and stop).
+
+## 6. Implementation (execution-style)
+
+For each finding you will address:
+
+1. **Read** the current files cited (and surrounding context). Understand neighboring patterns in the same plugin or package.
+2. **Change** the minimum amount of code needed to resolve the issue described; **match** local conventions (imports, naming, error handling, testing style) as in the **execute** workflow — the same repository patterns apply.
+3. **Tests** — follow the testing **pyramid**: prefer **unit** tests, add **integration** where appropriate; for **e2e**, prefer **Scout** (not the legacy Functional Test Runner). Only add or adjust tests when the finding calls for coverage or when behavior change requires it.
+4. **Run local checks** before finishing: use **`node scripts/check`** (lint + jest + tsc, auto-scoped to changed files). If it reports a failure, use the targeted re-run command it prints to iterate.
+5. Fix failures **you** introduce or expose.
+
+Collect a concise summary: finding number(s), files touched, nature of fix, and whether checks **passed**, **failed**, or were **not run** (with reason).
+
+## 7. Protected paths
+
+Do **not** modify:
+
+- Anything under **`.github/`**
+- **`.agents/personas/`**
+- **`AGENTS.md`**, **`CLAUDE.md`**
+- Workflow definition files
+
+If the finding **only** concerns protected paths, use **`add_comment`** to explain and **do not** push.
+
+## 8. Push and thread reply
+
+1. Use **`push_to_pull_request_branch`** once (after all intended edits for this activation) to update the **PR head** for this thread. **Do not** push or rewrite remotes outside that safe output.
+2. Post **one** final **`add_comment`** on the PR that confirms:
+   - Which finding number(s) you addressed (or that **`all`** requested items were attempted / which were skipped),
+   - What changed (paths + short description),
+   - Local check results.
+
+Keep comments **brief** and leave **`hide-older-comments`** behavior as configured — fix responses should remain visible in the timeline.
+
+## 9. Error handling
+
+If you cannot complete the work after starting a visible thread:
+
+- Use remaining **`add_comment`** budget to state what blocked you and what was already done.
+- Use **`report_incomplete`** when appropriate so the run is marked incomplete.
+
+Do not leave collaborators without an explanation after you have already posted an acknowledgment or started work.


### PR DESCRIPTION
## M2.c

Replaces the fix-feedback stub with a full workflow prompt supporting numbered follow-up requests on draft PRs.

- Parses `@kibana-agent fix <N>` and `fix all` from PR comments (trusted actors only)
- Locates the authoritative review comment and extracts the referenced finding
- Implements targeted fixes using execution-style approach (local conventions, testing pyramid, local checks)
- Pushes via `push-to-pull-request-branch`, posts a confirmation comment
- Design-level findings get an explanation instead of a speculative patch

Made with [Cursor](https://cursor.com)