### PR TITLE
feat(agent-factory): actionable review findings with follow-up commands

### DIFF
--- a/.agents/personas/synthesizer.md
+++ b/.agents/personas/synthesizer.md
@@ -20,8 +20,10 @@ You receive only the **merged set of findings** from the internal review pass (e
    - Kibana layout / local patterns / imports (when structural) → **`Conventions`**
    - Tests / coverage / runners → **`Tests`**
 4. **Auto-fix vs comment** — Items applied via `push_to_pull_request_branch` go under **Auto-fixed**; everything requiring judgment under **Findings** as numbered items.
-5. **Verdict** — One line: LGTM, Minor issues, or Needs revision, tied to the severity of remaining decision-tier items.
+5. **Actionability** — Each finding must state what is wrong **and** what the human should do about it. Drop findings that only say "consider" or "worth noting" without a concrete ask. If a finding cannot be made actionable, it is noise — omit it.
+6. **No padding** — If all issues were mechanical and auto-fixed, omit the Findings section. An empty findings list is a good outcome.
+7. **Verdict** — One line: LGTM, Minor issues, or Needs revision, tied to the severity of remaining decision-tier items.
 
 ## Output
 
-Match the workflow template: Summary, Auto-fixed, Findings (numbered `[Category]`), Verdict. **Never** output persona names or filenames from `.agents/personas/`.
+Match the workflow template: Summary, Auto-fixed, Findings (numbered `[Category]`), Verdict, and `@kibana-agent fix <number>` hint when findings exist. **Never** output persona names or filenames from `.agents/personas/`.

--- a/.github/workflows/kibana-agent-review.md
+++ b/.github/workflows/kibana-agent-review.md
@@ -116,15 +116,25 @@ Post **one** synthesized comment via the **`add_comment`** safe output, using th
 - <list of mechanical fixes applied, or "None">
 
 ### Findings
-1. **[Category]** <description> — `path/to/file.ts:L42`
-2. **[Category]** <description> — `path/to/file.ts:L88`
+1. **[Category]** <what is wrong and what the human should do about it> — `path/to/file.ts:L42`
+2. **[Category]** <what is wrong and what the human should do about it> — `path/to/file.ts:L88`
 ...
+
+To address a specific finding: `@kibana-agent fix <number>`
 
 ### Verdict
 <LGTM / Minor issues / Needs revision — with brief justification>
 ```
 
-Use only **`Scope`**, **`Quality`**, **`Conventions`**, or **`Tests`** as `[Category]`. If there are no findings, state that clearly. **Do not invent issues** to fill the template.
+Use only **`Scope`**, **`Quality`**, **`Conventions`**, or **`Tests`** as `[Category]`. If there are no findings, omit the **Findings** section and the follow-up command hint entirely. **Do not invent issues** to fill the template.
+
+### Finding quality rules
+
+Each decision-tier finding must be **actionable** — a human reading it should understand what to do next without re-investigating:
+
+- **State what is wrong**, citing a specific file, line range, or symbol.
+- **State what the human needs to decide or do.** "Consider whether X" is not actionable; "Choose between X (tradeoff A) and Y (tradeoff B)" is.
+- **Do not pad findings.** If the only issues are mechanical and were auto-fixed, say so in the summary and omit the Findings section. An empty findings list is a good outcome.
 
 ## 6. Reviewer independence
 


### PR DESCRIPTION
## M2.d

Tunes review comment quality so decision-tier findings are actionable for humans.

- Adds `@kibana-agent fix <number>` follow-up hint to the review comment template (connects review output to the fix-feedback workflow from M2.c)
- Adds finding quality rules: each finding must state what is wrong and what the human should do about it; vague "consider whether" findings are noise and should be omitted
- Updates the synthesizer persona with actionability and no-padding rules
- Omits the Findings section entirely when all issues were auto-fixed (empty findings is a good outcome)

Made with [Cursor](https://cursor.com)