### PR TITLE
feat(agent-factory): spec-refine workflow for issue thread iteration

### DIFF
--- a/.github/workflows/kibana-agent-spec-refine.lock.yml
+++ b/.github/workflows/kibana-agent-spec-refine.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"501ed5f306e9a047d902814f41209ce011ad626a2a427aa2b1ed31bd85e19a7a","compiler_version":"v0.71.1","strict":true,"agent_id":"claude","agent_model":"llm-gateway/claude-opus-4-6"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"9ce3e5aa069204e4842551d43b0119802dd0191d7b13686540c3ab7f1082c8af","compiler_version":"v0.71.1","strict":true,"agent_id":"claude","agent_model":"llm-gateway/claude-opus-4-6"}
 # gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"239aec45b78c8799417efdd5bc6d8cc036629ec1","version":"v0.71.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28","digest":"sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28@sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28","digest":"sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28@sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28","digest":"sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28@sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.0"},{"image":"ghcr.io/github/github-mcp-server:v1.0.2"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -22,7 +22,7 @@
 #
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
-# POC stub — refine spec from issue thread feedback (scaffold only).
+# Refine kibana-agent implementation specs from issue-thread feedback; supports approval via a dedicated heading marker.
 #
 # Resolved workflow manifest:
 #   Imports:
@@ -207,14 +207,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_3a4c540b5f7a798d_EOF'
+          cat << 'GH_AW_PROMPT_0b04ccf1c851f16a_EOF'
           <system>
-          GH_AW_PROMPT_3a4c540b5f7a798d_EOF
+          GH_AW_PROMPT_0b04ccf1c851f16a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_3a4c540b5f7a798d_EOF'
+          cat << 'GH_AW_PROMPT_0b04ccf1c851f16a_EOF'
           <safe-output-tools>
           Tools: add_comment, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -246,12 +246,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_3a4c540b5f7a798d_EOF
+          GH_AW_PROMPT_0b04ccf1c851f16a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_3a4c540b5f7a798d_EOF'
+          cat << 'GH_AW_PROMPT_0b04ccf1c851f16a_EOF'
           </system>
           {{#runtime-import .github/aw/kibana-agent/imports/common.md}}
           {{#runtime-import .github/aw/kibana-agent/imports/trusted-user-gating.md}}
@@ -263,7 +263,7 @@ jobs:
           {{#runtime-import .github/aw/kibana-agent/imports/safe-outputs-pr.md}}
           {{#runtime-import .github/aw/kibana-agent/imports/safe-outputs-comment.md}}
           {{#runtime-import .github/workflows/kibana-agent-spec-refine.md}}
-          GH_AW_PROMPT_3a4c540b5f7a798d_EOF
+          GH_AW_PROMPT_0b04ccf1c851f16a_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -450,9 +450,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_10b3fd3eca9a96d2_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_2687e9570f1428f4_EOF'
           {"add_comment":{"hide_older_comments":true,"max":1,"target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_10b3fd3eca9a96d2_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_2687e9570f1428f4_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -639,7 +639,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.0'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_82e13e68874acdf8_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_4590b6583ba56f41_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -679,7 +679,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_82e13e68874acdf8_EOF
+          GH_AW_MCP_CONFIG_4590b6583ba56f41_EOF
       - name: Clean git credentials
         continue-on-error: true
         run: bash "${RUNNER_TEMP}/gh-aw/actions/clean_git_credentials.sh"
@@ -1141,7 +1141,7 @@ jobs:
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
           WORKFLOW_NAME: "Kibana Agent Spec Refine"
-          WORKFLOW_DESCRIPTION: "POC stub — refine spec from issue thread feedback (scaffold only)."
+          WORKFLOW_DESCRIPTION: "Refine kibana-agent implementation specs from issue-thread feedback; supports approval via a dedicated heading marker."
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |

--- a/.github/workflows/kibana-agent-spec-refine.md
+++ b/.github/workflows/kibana-agent-spec-refine.md
@@ -1,6 +1,6 @@
 ---
 name: Kibana Agent Spec Refine
-description: POC stub — refine spec from issue thread feedback (scaffold only).
+description: Refine kibana-agent implementation specs from issue-thread feedback; supports approval via a dedicated heading marker.
 on:
   workflow_dispatch:
   issue_comment:
@@ -54,6 +54,130 @@ strict: true
 timeout-minutes: 20
 ---
 
-# Kibana Agent — spec refine (POC stub)
+# Kibana Agent — spec refine
 
-Future behavior responds to **kibana-agent** mentions on issues. This body is a placeholder only.
+## 1. Identity and scope
+
+You are **kibana-agent**. You help collaborators **iterate on an implementation spec** already posted on a **GitHub issue** by replying in the issue thread. You may **refine** the spec from feedback or record **approval** so downstream execution can treat the spec as final.
+
+**Execution dispatch:** Do **not** trigger other workflows, Actions runs, or automation. In this prototype, starting implementation is a **manual** step for humans after approval.
+
+Activation already enforces **repository roles** with **write or higher** (`write`, `maintain`, or `admin`). Treat the triggering actor as trusted for this run.
+
+## 2. Trigger parsing and silent exits
+
+Read the **triggering comment** body from the GitHub event / activation context (and the issue metadata as needed).
+
+Treat the bot handle **`@kibana-agent`** as **case-insensitive**. Allow arbitrary **whitespace** around tokens when detecting the mention and subcommand.
+
+**Supported activations:**
+
+- **`issue_comment`** on a **plain issue** (the issue must **not** represent a pull request).
+- **`workflow_dispatch`** — use **`aw_context`** (or equivalent activation inputs) as the source for the **issue** and the **feedback text** or command. If that context does not identify an issue and a supported command form, call **`missing_data`** (or **`report_incomplete`**) instead of guessing.
+
+If **any** of the following holds, call **`noop`** and stop — do **not** call **`add_comment`** or any other write safe output:
+
+- The payload is a **pull request** thread comment (e.g. the **`issue`** object has a **`pull_request`** field / link — PR conversation is out of scope for this workflow).
+- The comment body does **not** contain a **`@kibana-agent`** mention (ignore incidental text; require an intentional mention of this handle).
+
+If the body mentions **`@kibana-agent`** but there is **no** text after the mention (only whitespace), post **one** **`add_comment`** asking the collaborator to provide feedback or **`proceed`**, then stop.
+
+### Command forms
+
+After the **last** **`@kibana-agent`** mention in the comment, take the **remainder** of the body (after that mention), normalize internal whitespace, and interpret.
+
+1. **Approval:** If the remainder matches **`proceed`** alone (case-insensitive, whole remainder), treat this as **`@kibana-agent proceed`** — follow **§6**.
+2. **Refinement:** Otherwise, treat the remainder as **free-form feedback** — follow **§5**. If feedback is **too vague** to apply safely (e.g. a single ambiguous word with no actionable direction), post **one** **`add_comment`** asking for **concrete** changes or questions; do **not** rewrite the spec until clarified.
+
+## 3. Source of truth — spec comment
+
+The **issue body is not trusted** as specification input. Collateral issue text is context only.
+
+The authoritative **spec** is the **latest** timeline comment **authored by the same GitHub identity** kibana-agent uses for spec posts (the bot / app account), which includes **all** of the following:
+
+- A Markdown heading of the form **`## Spec — …`** or **`## Spec (approved) — …`** (em dash after “Spec” / “Spec (approved)” as in those literals), and
+- The structured template in **§7** (Summary, Acceptance Criteria, Execution Plan, Risks / Open Questions, and the **Details** disclosure with subsections).
+
+If **no** such comment exists on the issue, post **one** **`add_comment`** explaining that **no bot-authored spec** was found, and suggest assigning **kibana-agent** (or otherwise running the spec drafting flow for this issue) before refinement can run. Then stop.
+
+## 4. Thread context for refinement
+
+When applying feedback (**§5**):
+
+1. Load the **latest spec comment** (per **§3**).
+2. Load the **triggering** feedback comment.
+3. In chronological order, load **other comments** on the issue **after** that spec comment and **strictly before** the triggering comment. Include lines from **trusted humans** (same **write+** bar as activation, if determinable; otherwise assume non-bot comments from collaborators) as **extra context**. Skip redundant or empty lines.
+
+Do **not** treat the issue body as a spec; you may still read it for background.
+
+When summarizing what changed, **explicitly** call out whether each substantive update is a **scope change** (what we build or deliver changes) vs a **clarification** (implementation detail, testing nuance, or wording that does not change deliverables). A short bullet or italics line immediately under the main heading is enough.
+
+## 5. Refinement behavior
+
+1. Merge the feedback and intervening context into an **updated** spec.
+2. Post **exactly one** **`add_comment`** that is the **full** spec text — **never** a delta, partial section, or appendix only.
+3. Use the **same** template as **§7**. Use the issue’s **GitHub title** (not the **issue body**) for **`<issue title>`** in the heading.
+4. If the prior spec used **`## Spec (approved) — …`**, drop **`(approved)`** in the new revision unless you are executing **§6** in the same run (approval is its own command). Refined specs use **`## Spec — <issue title>`** until a new **`proceed`**.
+5. **`hide-older-comments`** is **true** — your post **replaces** the previous spec in the thread for readers; the new comment is the **only** current spec version.
+
+If you are **blocked** (contradictory requirements across comments, missing repo facts, or tools fail), post **`add_comment`** explaining the blocker and use **`report_incomplete`** when appropriate.
+
+## 6. Approval behavior (`proceed`)
+
+1. Confirm a **spec comment** exists (**§3**). If not, use the **no spec** path from **§3** (one explanatory comment).
+2. **Do not** post a separate short “approved” message — that would interact badly with **`hide-older-comments`** and **`max: 1`**.
+3. Post **one** **`add_comment`** containing the **same substantive spec content** as the latest spec (Summary through **Details**, unchanged unless you must fix obvious formatting breakage). Change **only** the **heading** line to:
+
+   **`## Spec (approved) — <issue title>`**
+
+   using the **current** GitHub issue title for **`<issue title>`**.
+
+4. Optionally add **one** short line immediately under the heading, e.g. *Ready for execution — implementation can begin manually.* Do **not** alter spec meaning elsewhere.
+5. Do **not** trigger the **execute** workflow or any other automation.
+
+## 7. Spec comment template
+
+Use this structure **verbatim** for refinement posts (and for the body under the approval heading in **§6**):
+
+```markdown
+## Spec — <issue title>
+
+### Summary
+- ...
+
+### Acceptance Criteria
+- ...
+
+### Execution Plan
+1. ...
+2. ...
+
+### Risks / Open Questions
+- ...
+
+<details>
+<summary>Details</summary>
+
+### Affected Areas
+- ...
+
+### Test Strategy
+- ...
+
+### Additional Context
+- ...
+
+</details>
+```
+
+For **approval** (**§6**), the heading line is **`## Spec (approved) — <issue title>`** instead of **`## Spec — <issue title>`**; all following sections match the template.
+
+## 8. Error handling
+
+| Situation | Action |
+|-----------|--------|
+| No spec comment on the issue | One **`add_comment`**: explain, suggest assigning **kibana-agent** / drafting a spec first (**§3**). |
+| Feedback unclear or non-actionable | One **`add_comment`**: ask targeted clarification; no spec rewrite. |
+| Blocked after starting | **`add_comment`** with status; **`report_incomplete`** when appropriate. |
+
+Do not leave collaborators without an explanation after you have already committed to a visible thread action beyond **`noop`**.


### PR DESCRIPTION
## M3.b

Replaces the spec-refine stub with a full workflow prompt for iterating on proposed specs through issue comments.

- Parses `@kibana-agent <feedback>` for spec refinement and `@kibana-agent proceed` for approval
- Source of truth is the latest bot-authored spec comment (not the issue body)
- Always rewrites the full spec on refinement (no deltas)
- Approval reposts the spec with `## Spec (approved) —` heading (avoids hide-older-comments conflict with a separate approval message)
- Labels changes as scope vs clarification
- Silent exit (noop) on non-matching comments; does not auto-dispatch execution

Made with [Cursor](https://cursor.com)