### PR TITLE
CI fix loop: local validation, flake handling, and escalation

### DIFF
--- a/.github/workflows/kibana-agent-ci-fix-loop.lock.yml
+++ b/.github/workflows/kibana-agent-ci-fix-loop.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"90f916634b9db6517d8f85fb24c28846879a71fb3ad07442fa5f20b969a22c1a","compiler_version":"v0.71.1","strict":true,"agent_id":"claude","agent_model":"llm-gateway/claude-opus-4-6"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"a7bcaad81baf52a146e1b9e2b9e331c09b97e999ec7968af54e14aa7d32ac608","compiler_version":"v0.71.1","strict":true,"agent_id":"claude","agent_model":"llm-gateway/claude-opus-4-6"}
 # gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"239aec45b78c8799417efdd5bc6d8cc036629ec1","version":"v0.71.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28","digest":"sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28@sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28","digest":"sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28@sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28","digest":"sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28@sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.0"},{"image":"ghcr.io/github/github-mcp-server:v1.0.2"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -22,7 +22,7 @@
 #
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
-# Diagnose CI failures, classify them, apply targeted fixes, and push through safe outputs.
+# Diagnose CI failures, classify them, validate locally, apply targeted fixes, and push through safe outputs with progress-aware escalation.
 #
 # Resolved workflow manifest:
 #   Imports:
@@ -202,19 +202,19 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_27ea709224cc8dd8_EOF'
+          cat << 'GH_AW_PROMPT_b94eba4641f2b6fd_EOF'
           <system>
-          GH_AW_PROMPT_27ea709224cc8dd8_EOF
+          GH_AW_PROMPT_b94eba4641f2b6fd_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_27ea709224cc8dd8_EOF'
+          cat << 'GH_AW_PROMPT_b94eba4641f2b6fd_EOF'
           <safe-output-tools>
           Tools: add_comment, push_to_pull_request_branch, missing_tool, missing_data, noop
-          GH_AW_PROMPT_27ea709224cc8dd8_EOF
+          GH_AW_PROMPT_b94eba4641f2b6fd_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_push_to_pr_branch.md"
-          cat << 'GH_AW_PROMPT_27ea709224cc8dd8_EOF'
+          cat << 'GH_AW_PROMPT_b94eba4641f2b6fd_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -244,9 +244,9 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_27ea709224cc8dd8_EOF
+          GH_AW_PROMPT_b94eba4641f2b6fd_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_27ea709224cc8dd8_EOF'
+          cat << 'GH_AW_PROMPT_b94eba4641f2b6fd_EOF'
           </system>
           {{#runtime-import .github/aw/kibana-agent/imports/common.md}}
           {{#runtime-import .github/aw/kibana-agent/imports/trusted-user-gating.md}}
@@ -258,7 +258,7 @@ jobs:
           {{#runtime-import .github/aw/kibana-agent/imports/safe-outputs-pr.md}}
           {{#runtime-import .github/aw/kibana-agent/imports/safe-outputs-comment.md}}
           {{#runtime-import .github/workflows/kibana-agent-ci-fix-loop.md}}
-          GH_AW_PROMPT_27ea709224cc8dd8_EOF
+          GH_AW_PROMPT_b94eba4641f2b6fd_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -445,9 +445,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_f8dec3c882121874_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_568dadcb2a456215_EOF'
           {"add_comment":{"hide_older_comments":true,"max":1,"target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_to_pull_request_branch":{"if_no_changes":"warn","max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","CLAUDE.md","AGENTS.md"],"protected_path_prefixes":[".github/",".agents/",".githooks/",".husky/",".claude/"],"target":"triggering"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_f8dec3c882121874_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_568dadcb2a456215_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -655,7 +655,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.0'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_1db22e017cea4e8a_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_00978043a5f7c126_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -695,7 +695,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_1db22e017cea4e8a_EOF
+          GH_AW_MCP_CONFIG_00978043a5f7c126_EOF
       - name: Clean git credentials
         continue-on-error: true
         run: bash "${RUNNER_TEMP}/gh-aw/actions/clean_git_credentials.sh"
@@ -771,7 +771,7 @@ jobs:
         # - mcp__github__search_repositories
         # - mcp__github__search_users
         # - mcp__safeoutputs
-        timeout-minutes: 45
+        timeout-minutes: 60
         run: |
           set -o pipefail
           touch /tmp/gh-aw/agent-step-summary.md
@@ -1064,7 +1064,7 @@ jobs:
           GH_AW_SAFE_OUTPUT_MESSAGES: "{\"activationComments\":\"false\"}"
           GH_AW_GROUP_REPORTS: "false"
           GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
-          GH_AW_TIMEOUT_MINUTES: "45"
+          GH_AW_TIMEOUT_MINUTES: "60"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -1159,7 +1159,7 @@ jobs:
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
           WORKFLOW_NAME: "Kibana Agent CI Fix Loop"
-          WORKFLOW_DESCRIPTION: "Diagnose CI failures, classify them, apply targeted fixes, and push through safe outputs."
+          WORKFLOW_DESCRIPTION: "Diagnose CI failures, classify them, validate locally, apply targeted fixes, and push through safe outputs with progress-aware escalation."
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |

--- a/.github/workflows/kibana-agent-ci-fix-loop.lock.yml
+++ b/.github/workflows/kibana-agent-ci-fix-loop.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"80e047254abd2749687b6de3d25f545bda5c9460d7d83176f7a430d240c82f50","compiler_version":"v0.71.1","strict":true,"agent_id":"claude","agent_model":"llm-gateway/claude-opus-4-6"}
-# gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"239aec45b78c8799417efdd5bc6d8cc036629ec1","version":"v0.71.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28","digest":"sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28@sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28","digest":"sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28@sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28","digest":"sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28@sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.0"},{"image":"ghcr.io/github/github-mcp-server:v1.0.2"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"90f916634b9db6517d8f85fb24c28846879a71fb3ad07442fa5f20b969a22c1a","compiler_version":"v0.71.1","strict":true,"agent_id":"claude","agent_model":"llm-gateway/claude-opus-4-6"}
+# gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"239aec45b78c8799417efdd5bc6d8cc036629ec1","version":"v0.71.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28","digest":"sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28@sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28","digest":"sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28@sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28","digest":"sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28@sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.0"},{"image":"ghcr.io/github/github-mcp-server:v1.0.2"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -22,7 +22,7 @@
 #
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
-# POC stub — CI diagnosis and fix loop (scaffold only; not M1.c entry workflow).
+# Diagnose CI failures, classify them, apply targeted fixes, and push through safe outputs.
 #
 # Resolved workflow manifest:
 #   Imports:
@@ -38,6 +38,7 @@
 #
 # Secrets used:
 #   - ANTHROPIC_API_KEY
+#   - GH_AW_CI_TRIGGER_TOKEN
 #   - GH_AW_GITHUB_MCP_SERVER_TOKEN
 #   - GH_AW_GITHUB_TOKEN
 #   - GITHUB_TOKEN
@@ -67,6 +68,15 @@ name: "Kibana Agent CI Fix Loop"
         description: Agent caller context (used internally by Agentic Workflows).
         required: false
         type: string
+  workflow_run:
+    # zizmor: ignore[dangerous-triggers] - workflow_run trigger is secured with role and fork validation
+    branches:
+    - poc/agent-factory
+    - agent/**
+    types:
+    - completed
+    workflows:
+    - Kibana Agent Factory (fork CI)
 
 permissions: {}
 
@@ -77,6 +87,11 @@ run-name: "Kibana Agent CI Fix Loop"
 
 jobs:
   activation:
+    needs: pre_activation
+    # zizmor: ignore[dangerous-triggers] - workflow_run trigger is secured with role and fork validation
+    if: >
+      (needs.pre_activation.outputs.activated == 'true') && (github.event_name != 'workflow_run' || github.event.workflow_run.repository.id == github.repository_id &&
+      (!(github.event.workflow_run.repository.fork)))
     runs-on: ubuntu-slim
     permissions:
       actions: read
@@ -97,6 +112,7 @@ jobs:
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
+          trace-id: ${{ needs.pre_activation.outputs.setup-trace-id }}
       - name: Generate agentic run info
         id: generate_aw_info
         env:
@@ -186,16 +202,19 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_90eb87b7731fca12_EOF'
+          cat << 'GH_AW_PROMPT_27ea709224cc8dd8_EOF'
           <system>
-          GH_AW_PROMPT_90eb87b7731fca12_EOF
+          GH_AW_PROMPT_27ea709224cc8dd8_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_90eb87b7731fca12_EOF'
+          cat << 'GH_AW_PROMPT_27ea709224cc8dd8_EOF'
           <safe-output-tools>
-          Tools: add_comment, missing_tool, missing_data, noop
+          Tools: add_comment, push_to_pull_request_branch, missing_tool, missing_data, noop
+          GH_AW_PROMPT_27ea709224cc8dd8_EOF
+          cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_push_to_pr_branch.md"
+          cat << 'GH_AW_PROMPT_27ea709224cc8dd8_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -225,9 +244,9 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_90eb87b7731fca12_EOF
+          GH_AW_PROMPT_27ea709224cc8dd8_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_90eb87b7731fca12_EOF'
+          cat << 'GH_AW_PROMPT_27ea709224cc8dd8_EOF'
           </system>
           {{#runtime-import .github/aw/kibana-agent/imports/common.md}}
           {{#runtime-import .github/aw/kibana-agent/imports/trusted-user-gating.md}}
@@ -239,7 +258,7 @@ jobs:
           {{#runtime-import .github/aw/kibana-agent/imports/safe-outputs-pr.md}}
           {{#runtime-import .github/aw/kibana-agent/imports/safe-outputs-comment.md}}
           {{#runtime-import .github/workflows/kibana-agent-ci-fix-loop.md}}
-          GH_AW_PROMPT_90eb87b7731fca12_EOF
+          GH_AW_PROMPT_27ea709224cc8dd8_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -263,6 +282,7 @@ jobs:
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
+          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: ${{ needs.pre_activation.outputs.activated }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -281,7 +301,8 @@ jobs:
                 GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: process.env.GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER,
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
-                GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE
+                GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
+                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED
               }
             });
       - name: Validate prompt placeholders
@@ -317,6 +338,8 @@ jobs:
       issues: read
       models: read
       pull-requests: read
+    concurrency:
+      group: "gh-aw-claude-${{ github.workflow }}"
     env:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       GH_AW_ASSETS_ALLOWED_EXTS: ""
@@ -422,15 +445,16 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_5a528da9714e6b4a_EOF'
-          {"add_comment":{"hide_older_comments":true,"max":1,"target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_5a528da9714e6b4a_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_f8dec3c882121874_EOF'
+          {"add_comment":{"hide_older_comments":true,"max":1,"target":"*"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_to_pull_request_branch":{"if_no_changes":"warn","max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","CLAUDE.md","AGENTS.md"],"protected_path_prefixes":[".github/",".agents/",".githooks/",".husky/",".claude/"],"target":"triggering"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_f8dec3c882121874_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added. Target: *. Supports reply_to_id for discussion threading."
+                "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added. Target: *. Supports reply_to_id for discussion threading.",
+                "push_to_pull_request_branch": " CONSTRAINTS: Maximum 1 push(es) can be made."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -513,6 +537,26 @@ jobs:
                     "type": "string",
                     "sanitize": true,
                     "maxLength": 65000
+                  }
+                }
+              },
+              "push_to_pull_request_branch": {
+                "defaultMax": 1,
+                "fields": {
+                  "branch": {
+                    "required": true,
+                    "type": "string",
+                    "sanitize": true,
+                    "maxLength": 256
+                  },
+                  "message": {
+                    "required": true,
+                    "type": "string",
+                    "sanitize": true,
+                    "maxLength": 65000
+                  },
+                  "pull_request_number": {
+                    "issueOrPRNumber": true
                   }
                 }
               },
@@ -611,7 +655,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.0'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_7d37c03e20f925b6_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_1db22e017cea4e8a_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -651,7 +695,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_7d37c03e20f925b6_EOF
+          GH_AW_MCP_CONFIG_1db22e017cea4e8a_EOF
       - name: Clean git credentials
         continue-on-error: true
         run: bash "${RUNNER_TEMP}/gh-aw/actions/clean_git_credentials.sh"
@@ -727,7 +771,7 @@ jobs:
         # - mcp__github__search_repositories
         # - mcp__github__search_users
         # - mcp__safeoutputs
-        timeout-minutes: 20
+        timeout-minutes: 45
         run: |
           set -o pipefail
           touch /tmp/gh-aw/agent-step-summary.md
@@ -904,7 +948,7 @@ jobs:
       needs.activation.outputs.stale_lock_file_failed == 'true')
     runs-on: ubuntu-slim
     permissions:
-      contents: read
+      contents: write
       discussions: write
       issues: write
       pull-requests: write
@@ -1013,12 +1057,14 @@ jobs:
           GH_AW_ENGINE_ID: "claude"
           GH_AW_SECRET_VERIFICATION_RESULT: ${{ needs.activation.outputs.secret_verification_result }}
           GH_AW_CHECKOUT_PR_SUCCESS: ${{ needs.agent.outputs.checkout_pr_success }}
+          GH_AW_CODE_PUSH_FAILURE_ERRORS: ${{ needs.safe_outputs.outputs.code_push_failure_errors }}
+          GH_AW_CODE_PUSH_FAILURE_COUNT: ${{ needs.safe_outputs.outputs.code_push_failure_count }}
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
           GH_AW_STALE_LOCK_FILE_FAILED: ${{ needs.activation.outputs.stale_lock_file_failed }}
           GH_AW_SAFE_OUTPUT_MESSAGES: "{\"activationComments\":\"false\"}"
           GH_AW_GROUP_REPORTS: "false"
           GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
-          GH_AW_TIMEOUT_MINUTES: "20"
+          GH_AW_TIMEOUT_MINUTES: "45"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -1113,7 +1159,7 @@ jobs:
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
           WORKFLOW_NAME: "Kibana Agent CI Fix Loop"
-          WORKFLOW_DESCRIPTION: "POC stub — CI diagnosis and fix loop (scaffold only; not M1.c entry workflow)."
+          WORKFLOW_DESCRIPTION: "Diagnose CI failures, classify them, apply targeted fixes, and push through safe outputs."
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |
@@ -1200,6 +1246,32 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/parse_threat_detection_results.cjs');
             await main();
 
+  pre_activation:
+    runs-on: ubuntu-slim
+    outputs:
+      activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
+      matched_command: ''
+      setup-trace-id: ${{ steps.setup.outputs.trace-id }}
+    steps:
+      - name: Setup Scripts
+        id: setup
+        uses: github/gh-aw-actions/setup@239aec45b78c8799417efdd5bc6d8cc036629ec1 # v0.71.1
+        with:
+          destination: ${{ runner.temp }}/gh-aw/actions
+          job-name: ${{ github.job }}
+      - name: Check team membership for workflow
+        id: check_membership
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        env:
+          GH_AW_REQUIRED_ROLES: "admin,maintainer,write"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
+            setupGlobals(core, github, context, exec, io, getOctokit);
+            const { main } = require('${{ runner.temp }}/gh-aw/actions/check_membership.cjs');
+            await main();
+
   safe_outputs:
     needs:
       - activation
@@ -1208,7 +1280,7 @@ jobs:
     if: (!cancelled()) && needs.agent.result != 'skipped' && needs.detection.result == 'success'
     runs-on: ubuntu-slim
     permissions:
-      contents: read
+      contents: write
       discussions: write
       issues: write
       pull-requests: write
@@ -1233,6 +1305,8 @@ jobs:
       create_discussion_errors: ${{ steps.process_safe_outputs.outputs.create_discussion_errors }}
       process_safe_outputs_processed_count: ${{ steps.process_safe_outputs.outputs.processed_count }}
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
+      push_commit_sha: ${{ steps.process_safe_outputs.outputs.push_commit_sha }}
+      push_commit_url: ${{ steps.process_safe_outputs.outputs.push_commit_url }}
     steps:
       - name: Setup Scripts
         id: setup
@@ -1255,6 +1329,34 @@ jobs:
           mkdir -p /tmp/gh-aw/
           find "/tmp/gh-aw/" -type f -print
           echo "GH_AW_AGENT_OUTPUT=/tmp/gh-aw/agent_output.json" >> "$GITHUB_OUTPUT"
+      - name: Download patch artifact
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: agent
+          path: /tmp/gh-aw/
+      - name: Checkout repository
+        if: (!cancelled()) && needs.agent.result != 'skipped' && contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch')
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.base_ref || github.event.pull_request.base.ref || github.ref_name || github.event.repository.default_branch }}
+          token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          persist-credentials: false
+          fetch-depth: 1
+      - name: Configure Git credentials
+        if: (!cancelled()) && needs.agent.result != 'skipped' && contains(needs.agent.outputs.output_types, 'push_to_pull_request_branch')
+        env:
+          REPO_NAME: ${{ github.repository }}
+          SERVER_URL: ${{ github.server_url }}
+          GIT_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git config --global am.keepcr true
+          # Re-authenticate git with GitHub token
+          SERVER_URL_STRIPPED="${SERVER_URL#https://}"
+          git remote set-url origin "https://x-access-token:${GIT_TOKEN}@${SERVER_URL_STRIPPED}/${REPO_NAME}.git"
+          echo "Git configured with standard GitHub Actions identity"
       - name: Configure GH_HOST for enterprise compatibility
         id: ghes-host-config
         shell: bash
@@ -1272,7 +1374,8 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.buildkite.com,*.elastic.co,*.elastic.dev,*.githubusercontent.com,anthropic.com,api.anthropic.com,api.github.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,buildkite.com,cdn.playwright.dev,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,elastic.co,elastic.dev,elastic.litellm-prod.ai,files.pythonhosted.org,ghcr.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,playwright.download.prss.microsoft.com,ppa.launchpad.net,pypi.org,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,sentry.io,statsig.anthropic.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":1,\"target\":\"*\"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":1,\"target\":\"*\"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"push_to_pull_request_branch\":{\"if_no_changes\":\"warn\",\"max\":1,\"max_patch_size\":1024,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"CLAUDE.md\",\"AGENTS.md\"],\"protected_path_prefixes\":[\".github/\",\".agents/\",\".githooks/\",\".husky/\",\".claude/\"],\"target\":\"triggering\"},\"report_incomplete\":{}}"
+          GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/kibana-agent-ci-fix-loop.md
+++ b/.github/workflows/kibana-agent-ci-fix-loop.md
@@ -1,8 +1,14 @@
 ---
 name: Kibana Agent CI Fix Loop
-description: POC stub — CI diagnosis and fix loop (scaffold only; not M1.c entry workflow).
+description: Diagnose CI failures, classify them, apply targeted fixes, and push through safe outputs.
 on:
   workflow_dispatch:
+  workflow_run:
+    workflows: ["Kibana Agent Factory (fork CI)"]
+    types: [completed]
+    branches:
+      - poc/agent-factory
+      - "agent/**"
 
 permissions:
   contents: read
@@ -37,21 +43,146 @@ tools:
   web-fetch:
   bash: true
 
-
 safe-outputs:
   activation-comments: false
   report-failure-as-issue: false
   threat-detection:
     enabled: true
+  push-to-pull-request-branch:
+    target: "triggering"
+    max: 1
   add-comment:
     max: 1
     target: "*"
     hide-older-comments: true
 
 strict: true
-timeout-minutes: 20
+timeout-minutes: 45
 ---
 
-# Kibana Agent — CI fix loop (POC stub)
+# Kibana Agent — CI fix loop
 
-M1.c will add the conventional Actions entry workflow. This gh-aw source exists so the factory layout compiles end-to-end.
+## 1. Identity and role
+
+You are **kibana-agent**, working to converge a draft pull request toward green CI in the Kibana monorepo. You diagnose CI failures, classify them, apply targeted fixes, and push through safe outputs.
+
+You push fixes through **`push_to_pull_request_branch`** and post status updates through **`add_comment`**. You never have direct write access to remotes or tokens outside safe outputs.
+
+## 2. Activation and PR resolution
+
+This workflow triggers when the fork CI workflow completes (`workflow_run`) or via manual dispatch (`workflow_dispatch`).
+
+### From `workflow_run`
+
+1. Read the triggering workflow run from the activation context.
+2. Extract the associated pull request. The `workflow_run` event includes `workflow_run.pull_requests` — use the first entry. If no PR is associated, call **`noop`** and stop.
+3. Read the workflow run conclusion. If it is **`success`**, call **`noop`** and stop — there is nothing to fix.
+4. If the conclusion is **`cancelled`** or **`skipped`**, call **`noop`** and stop.
+
+### From `workflow_dispatch`
+
+If triggered manually, resolve the target PR from the activation context or `aw_context` payload. If no PR can be identified, call **`missing_data`** and stop.
+
+### PR validation
+
+Before proceeding, confirm the PR:
+
+- Is **open** (not closed or merged).
+- Was authored by the **kibana-agent** identity or is on a bot-owned branch (prefix `agent/`).
+- Targets a branch this workflow is configured to operate on.
+
+If any check fails, call **`noop`** and stop.
+
+## 3. Failure log retrieval
+
+1. Fetch the **failed workflow run** details: jobs, steps, and their conclusions.
+2. For each **failed job**, retrieve the step logs. Focus on the **first failure** in each job — downstream steps often fail as a consequence.
+3. Extract the **relevant error output**: compiler diagnostics, lint messages, test failure summaries, build errors, or infrastructure messages.
+4. Keep log excerpts **focused** — include enough context to diagnose but do not paste entire log output into working memory.
+
+If logs are **unavailable** or **access is denied** (e.g. Buildkite logs behind authentication), note the gap in your status comment and work from GitHub check annotations and status messages.
+
+## 4. Failure classification
+
+Classify each distinct failure into **exactly one** category:
+
+| Category | Signal patterns |
+|----------|----------------|
+| **type** | `TS\d+` errors, `tsc` failures, type-check step failures, "Type '…' is not assignable" |
+| **lint** | ESLint errors, `eslint` step failures, rule violation messages |
+| **unit-test** | Jest failures, `FAIL` lines with test file paths, assertion errors in `*.test.ts` files |
+| **build** | Webpack/esbuild errors, bundle failures, missing module resolution outside type errors |
+| **flake** | Test failures that appear non-deterministic — same test passes on retry or on the base branch without code changes |
+| **infrastructure** | Runner provisioning failures, network timeouts to external services, GitHub Actions internal errors, OOM kills, `timeout-minutes` exceeded without a code-related root cause |
+
+**Classification rules:**
+
+- When a single CI run has **multiple failures**, classify each independently. Address them in priority order: **type → lint → unit-test → build** (fix foundational issues first since they often cascade).
+- If a failure does not fit any category, classify it as **infrastructure** and note the ambiguity in the status comment.
+- Record the classification, the error message or pattern signature, and the affected file(s) for each failure.
+
+## 5. Fix implementation
+
+For each failure classified as **type**, **lint**, **unit-test**, or **build**, attempt a targeted fix:
+
+1. **Read** the failing files and surrounding context. Understand the local patterns in the same plugin or package.
+2. **Diagnose** the root cause from the error output and the PR's diff. Trace type errors to their source, lint violations to the rule, test failures to the assertion.
+3. **Fix** the minimum code needed to resolve the failure. Match local conventions (imports, naming, error handling, TypeScript patterns) as established in the surrounding codebase.
+4. **Do not** expand scope beyond what the CI failure requires. If a fix would require architectural changes or design decisions, note the issue in the status comment and skip that failure.
+
+### Fix quality
+
+- Prefer fixes that address the root cause over those that suppress the symptom.
+- Do not add `@ts-ignore`, `@ts-expect-error`, `eslint-disable`, or skip/xfail directives to silence failures.
+- Follow the **testing pyramid**: if a fix changes behavior, add or update the appropriate test level (unit preferred, then integration, then e2e with Scout).
+
+For **flake** or **infrastructure** failures, do not attempt a code fix. Note the classification in the status comment.
+
+## 6. Push and status comment
+
+After applying fixes:
+
+1. Use **`push_to_pull_request_branch`** to push the fix commit(s) to the PR head branch.
+2. Post **one** status comment via **`add_comment`** using this format:
+
+```markdown
+## CI Fix
+
+### Failures
+| Category | Pattern | File(s) | Action |
+|----------|---------|---------|--------|
+| type | TS2345: Argument of type '…' | `src/path/file.ts` | Fixed: corrected parameter type |
+| lint | no-unused-vars | `src/path/other.ts` | Fixed: removed unused import |
+| flake | Intermittent timeout in test_name | `src/path/test.ts` | Skipped: appears non-deterministic |
+
+### Status
+**Fix pushed** — waiting for next CI run.
+```
+
+Adjust the **Status** line based on the outcome:
+
+- **Fix pushed** — at least one fix was applied and pushed.
+- **No action needed** — all failures were flakes or infrastructure issues.
+- **Blocked** — failures require changes outside this workflow's scope (see §7 for protected files).
+
+If there is **nothing to fix** (all failures are flakes or infrastructure), post the status comment but **skip the push**.
+
+## 7. Protected files
+
+Do **not** modify:
+
+- Anything under **`.github/`**
+- **`.agents/personas/`**
+- **`AGENTS.md`**, **`CLAUDE.md`**
+- Workflow definition files
+
+If a CI failure can only be resolved by changing protected files, note this in the status comment.
+
+## 8. Error handling
+
+If you cannot complete the work:
+
+1. Post an **`add_comment`** explaining what blocked you and what was already done.
+2. Call **`report_incomplete`** so the run is marked incomplete.
+
+Do not leave the PR without a visible status update when stopping early.

--- a/.github/workflows/kibana-agent-ci-fix-loop.md
+++ b/.github/workflows/kibana-agent-ci-fix-loop.md
@@ -1,6 +1,6 @@
 ---
 name: Kibana Agent CI Fix Loop
-description: Diagnose CI failures, classify them, apply targeted fixes, and push through safe outputs.
+description: Diagnose CI failures, classify them, validate locally, apply targeted fixes, and push through safe outputs with progress-aware escalation.
 on:
   workflow_dispatch:
   workflow_run:
@@ -57,14 +57,14 @@ safe-outputs:
     hide-older-comments: true
 
 strict: true
-timeout-minutes: 45
+timeout-minutes: 60
 ---
 
 # Kibana Agent — CI fix loop
 
 ## 1. Identity and role
 
-You are **kibana-agent**, working to converge a draft pull request toward green CI in the Kibana monorepo. You diagnose CI failures, classify them, apply targeted fixes, and push through safe outputs.
+You are **kibana-agent**, working to converge a draft pull request toward green CI in the Kibana monorepo. You diagnose CI failures, classify them, apply targeted fixes, validate locally before pushing, and escalate when the loop is no longer making useful progress.
 
 You push fixes through **`push_to_pull_request_branch`** and post status updates through **`add_comment`**. You never have direct write access to remotes or tokens outside safe outputs.
 
@@ -75,10 +75,7 @@ This workflow triggers when the fork CI workflow completes (`workflow_run`) or v
 ### From `workflow_run`
 
 1. Read the triggering workflow run from the activation context.
-2. Resolve the associated pull request:
-   - Read the **head SHA** and **head branch** from the completed workflow run.
-   - Search for an **open** pull request whose head commit matches that SHA (for example via the GitHub API — list pull requests associated with that commit or repository search with `type:pr is:open` plus the SHA).
-   - If no PR is found, call **`noop`** and stop.
+2. Extract the associated pull request. The `workflow_run` event includes `workflow_run.pull_requests` — use the first entry. If no PR is associated, call **`noop`** and stop.
 3. Read the workflow run conclusion. If it is **`success`**, call **`noop`** and stop — there is nothing to fix.
 4. If the conclusion is **`cancelled`** or **`skipped`**, call **`noop`** and stop.
 
@@ -115,23 +112,92 @@ Classify each distinct failure into **exactly one** category:
 | **lint** | ESLint errors, `eslint` step failures, rule violation messages |
 | **unit-test** | Jest failures, `FAIL` lines with test file paths, assertion errors in `*.test.ts` files |
 | **build** | Webpack/esbuild errors, bundle failures, missing module resolution outside type errors |
-| **flake** | Test failures that appear non-deterministic — same test passes on retry or on the base branch without code changes |
 | **infrastructure** | Runner provisioning failures, network timeouts to external services, GitHub Actions internal errors, OOM kills, `timeout-minutes` exceeded without a code-related root cause |
 
 **Classification rules:**
 
 - When a single CI run has **multiple failures**, classify each independently. Address them in priority order: **type → lint → unit-test → build** (fix foundational issues first since they often cascade).
 - If a failure does not fit any category, classify it as **infrastructure** and note the ambiguity in the status comment.
-- Record the classification, the error message or pattern signature, and the affected file(s) for each failure.
+- Record the classification, the error message or pattern signature, and the affected file(s) for each failure. This feeds progress tracking in §5.
 
-## 5. Fix implementation
+## 5. Progress tracking
 
-For each failure classified as **type**, **lint**, **unit-test**, or **build**, attempt a targeted fix:
+Determine how many prior fix iterations have occurred on this PR and whether progress is being made.
+
+1. **Count previous iterations.** Query the workflow run history for this workflow on the current PR's head branch. Each completed run of the CI fix loop (regardless of outcome) counts as one iteration.
+2. **Collect error patterns from prior runs.** Read any previous **kibana-agent** status comments on the PR that follow the format from §10. Extract the **failure category** and **pattern signature** from each.
+3. **Detect repeated failures.** Compare the current failure's category and pattern signature against the collected history. A failure is **repeated** if the same category and substantially similar error pattern appeared in a prior iteration without an intervening successful CI run.
+
+**Escalation thresholds** — see §11 for actions when thresholds are met:
+
+- **3 repeated failures** of the same error pattern (same category + similar diagnostic), OR
+- **10 total fix iterations** on this PR (regardless of error diversity)
+
+Whichever threshold is reached first triggers escalation.
+
+## 6. CI results and flake handling
+
+Before attempting a fix, check whether the build actually failed or was already classified as flaky by the CI infrastructure.
+
+### CI results comment
+
+In the Kibana repository, build results are posted as a structured comment on the PR. Look for the **latest** comment matching the Buildkite CI format (contains a `buildkite-pr-comment` HTML block). The heading indicates the build outcome:
+
+- **`:green_heart: Build Succeeded`** — all tests passed. No action needed.
+- **`:yellow_heart: Build succeeded, but was flaky`** — the build passed but some tests were flaky. CI has already classified these as non-deterministic. No fix needed.
+- **`:broken_heart: Build Failed`** — real failures listed under **Failed CI Steps** and optionally **Test Failures**. These are the failures to diagnose and fix.
+
+The comment includes a structured JSON payload in an HTML comment (`buildkite-pr-comment`) with `buildStatus.success` (boolean) and `buildStatus.state` fields.
+
+### Handling
+
+- **Green heart or yellow heart:** Do not count against the retry budget. Do not attempt a fix. Post a brief status comment noting CI passed (or was flaky) and stop.
+- **Broken heart:** Parse the **Failed CI Steps** and **Test Failures** sections for error details. Use linked build job logs where accessible. Proceed to failure classification in §4 and fix implementation in §8.
+- **No CI results comment found:** Fall back to reading the workflow run conclusion and job logs directly (§3). This is expected in environments without Buildkite integration.
+
+## 7. Local validation
+
+Before pushing any fix, validate locally to avoid wasting CI cycles on changes that will obviously fail again.
+
+### Primary gate
+
+Run **`node scripts/check`** as the default pre-push validation. It runs lint (with auto-fix), affected Jest tests, and type-checking in one pass, automatically scoped to changed files.
+
+### Targeted re-runs
+
+When `node scripts/check` fails, use the targeted commands it prints to iterate on specific failures:
+
+- **Type errors:** `node scripts/type_check --project <tsconfig>`
+- **Lint errors:** `node scripts/eslint --fix <changed-files>`
+- **Test failures:** `node scripts/jest <path-or-pattern>`
+
+### Package discovery
+
+To determine which packages are affected:
+
+1. Compute the merge base: `git merge-base HEAD <target-branch>`
+2. Collect changed and untracked files relative to the merge base.
+3. Walk upward from each changed file to the nearest `kibana.jsonc`.
+4. Derive the affected package IDs and `tsconfig.json` paths from there.
+
+Do **not** infer affected packages from `src/<area>` path heuristics.
+
+### Validation rules
+
+- Run `node scripts/check` **at least once** before pushing. If it passes, push.
+- If `node scripts/check` fails on something you just fixed, iterate using the targeted commands (up to **3 local fix-and-recheck cycles**) before giving up on that failure.
+- If local validation still fails after local retries, do **not** push. Escalate per §11.
+- If `node scripts/check` is unavailable (e.g. bootstrap issues), fall back to running the individual lint, type-check, and test commands listed above. Note the fallback in the status comment.
+
+## 8. Fix implementation
+
+For each failure classified in §4 as **type**, **lint**, **unit-test**, or **build**, attempt a targeted fix:
 
 1. **Read** the failing files and surrounding context. Understand the local patterns in the same plugin or package.
 2. **Diagnose** the root cause from the error output and the PR's diff. Trace type errors to their source, lint violations to the rule, test failures to the assertion.
 3. **Fix** the minimum code needed to resolve the failure. Match local conventions (imports, naming, error handling, TypeScript patterns) as established in the surrounding codebase.
-4. **Do not** expand scope beyond what the CI failure requires. If a fix would require architectural changes or design decisions, note the issue in the status comment and skip that failure.
+4. **Do not** expand scope beyond what the CI failure requires. If a fix would require architectural changes or design decisions, escalate per §11 instead of guessing.
+5. **Run local validation** per §7 before marking the fix complete.
 
 ### Fix quality
 
@@ -139,38 +205,7 @@ For each failure classified as **type**, **lint**, **unit-test**, or **build**, 
 - Do not add `@ts-ignore`, `@ts-expect-error`, `eslint-disable`, or skip/xfail directives to silence failures.
 - Follow the **testing pyramid**: if a fix changes behavior, add or update the appropriate test level (unit preferred, then integration, then e2e with Scout).
 
-For **flake** or **infrastructure** failures, do not attempt a code fix. Note the classification in the status comment.
-
-## 6. Push and status comment
-
-After applying fixes:
-
-1. Use **`push_to_pull_request_branch`** to push the fix commit(s) to the PR head branch.
-2. Post **one** status comment via **`add_comment`** using this format:
-
-```markdown
-## CI Fix
-
-### Failures
-| Category | Pattern | File(s) | Action |
-|----------|---------|---------|--------|
-| type | TS2345: Argument of type '…' | `src/path/file.ts` | Fixed: corrected parameter type |
-| lint | no-unused-vars | `src/path/other.ts` | Fixed: removed unused import |
-| flake | Intermittent timeout in test_name | `src/path/test.ts` | Skipped: appears non-deterministic |
-
-### Status
-**Fix pushed** — waiting for next CI run.
-```
-
-Adjust the **Status** line based on the outcome:
-
-- **Fix pushed** — at least one fix was applied and pushed.
-- **No action needed** — all failures were flakes or infrastructure issues.
-- **Blocked** — failures require changes outside this workflow's scope (see §7 for protected files).
-
-If there is **nothing to fix** (all failures are flakes or infrastructure), post the status comment but **skip the push**.
-
-## 7. Protected files
+## 9. Protected files
 
 Do **not** modify:
 
@@ -179,9 +214,70 @@ Do **not** modify:
 - **`AGENTS.md`**, **`CLAUDE.md`**
 - Workflow definition files
 
-If a CI failure can only be resolved by changing protected files, note this in the status comment.
+If a CI failure can only be resolved by changing protected files, escalate per §11.
 
-## 8. Error handling
+## 10. Push and status comment
+
+After applying fixes and passing local validation:
+
+1. Use **`push_to_pull_request_branch`** to push the fix commit(s) to the PR head branch.
+2. Post **one** status comment via **`add_comment`** using this format:
+
+```markdown
+## CI Fix — iteration N
+
+### Failures
+| Category | Pattern | File(s) | Action |
+|----------|---------|---------|--------|
+| type | TS2345: Argument of type '…' | `src/path/file.ts` | Fixed: corrected parameter type |
+| lint | no-unused-vars | `src/path/other.ts` | Fixed: removed unused import |
+
+### Skipped
+- <CI-classified flaky tests or infrastructure issues, if any — or "None">
+
+### Local validation
+- `node scripts/check`: **pass** / **fail** (details if relevant)
+
+### Progress
+- Iteration: N of 10 max
+- Repeated-pattern count for current failure(s): M of 3 max
+- Status: **fix pushed** / **escalated** / **no action needed**
+```
+
+Adjust the **Status** line based on the outcome:
+
+- **Fix pushed** — at least one fix was applied, local validation passed, and changes were pushed.
+- **No action needed** — all failures were CI-classified flakes or infrastructure issues.
+- **Escalated** — an escalation threshold was reached (see §11).
+- **Blocked** — failures require changes to protected files or architectural decisions.
+
+If there is **nothing to fix** (all failures are flakes or infrastructure), post the status comment but **skip the push**.
+
+## 11. Escalation
+
+Escalate when the fix loop is no longer making useful progress. Escalation means **stopping the loop and requesting human help**.
+
+### Triggers
+
+Escalate if **any** of the following is true:
+
+- The **same error pattern** (category + similar diagnostic message) has failed **3 times** across iterations without an intervening CI pass.
+- The PR has reached **10 total fix iterations** (regardless of whether errors are different each time).
+- A failure is classified as **infrastructure** and is not transient (persists across 2+ runs).
+- Local validation **cannot pass** after 3 local fix-and-recheck cycles.
+- The required fix would involve **protected files**, **architectural decisions**, or **scope beyond the original PR**.
+
+### Escalation action
+
+1. **Do not push** any further changes.
+2. Post **one** **`add_comment`** that:
+   - States the loop is escalating to a human.
+   - Lists the persistent failure(s) with category, pattern, and relevant log excerpts.
+   - Summarizes what was tried across iterations.
+   - Includes the iteration count and which threshold was hit.
+3. Call **`report_incomplete`** so the run is marked as needing human intervention.
+
+## 12. Error handling
 
 If you cannot complete the work:
 

--- a/.github/workflows/kibana-agent-ci-fix-loop.md
+++ b/.github/workflows/kibana-agent-ci-fix-loop.md
@@ -75,7 +75,10 @@ This workflow triggers when the fork CI workflow completes (`workflow_run`) or v
 ### From `workflow_run`
 
 1. Read the triggering workflow run from the activation context.
-2. Extract the associated pull request. The `workflow_run` event includes `workflow_run.pull_requests` — use the first entry. If no PR is associated, call **`noop`** and stop.
+2. Resolve the associated pull request:
+   - Read the **head SHA** and **head branch** from the completed workflow run.
+   - Search for an **open** pull request whose head commit matches that SHA (for example via the GitHub API — list pull requests associated with that commit or repository search with `type:pr is:open` plus the SHA).
+   - If no PR is found, call **`noop`** and stop.
 3. Read the workflow run conclusion. If it is **`success`**, call **`noop`** and stop — there is nothing to fix.
 4. If the conclusion is **`cancelled`** or **`skipped`**, call **`noop`** and stop.
 

--- a/.github/workflows/kibana-agent-ci.yml
+++ b/.github/workflows/kibana-agent-ci.yml
@@ -20,6 +20,7 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   verify:
@@ -51,3 +52,82 @@ jobs:
 
       - name: ESLint @kbn/repo-info sources
         run: node scripts/eslint.js src/platform/packages/shared/kbn-repo-info
+
+  ci-results-comment:
+    name: Post CI results comment
+    runs-on: ubuntu-latest
+    needs: [verify]
+    if: always() && github.event_name == 'pull_request'
+    steps:
+      - name: Post CI results
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const buildNumber = context.runNumber;
+            const buildUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const commit = context.payload.pull_request.head.sha;
+            const verifyResult = '${{ needs.verify.result }}';
+
+            let emoji, title, state, success;
+            if (verifyResult === 'success') {
+              emoji = ':green_heart:';
+              title = 'Build Succeeded';
+              state = 'passed';
+              success = true;
+            } else if (verifyResult === 'cancelled') {
+              return;
+            } else {
+              emoji = ':broken_heart:';
+              title = 'Build Failed';
+              state = 'failed';
+              success = false;
+            }
+
+            const failedSteps = [];
+            if (!success) {
+              failedSteps.push(`* [Bootstrap, typecheck, eslint](${buildUrl})`);
+            }
+
+            let body = `## ${emoji} ${title}\n`;
+            body += `* [GitHub Actions Build](${buildUrl})\n`;
+            body += `* Commit: ${commit}\n`;
+            if (failedSteps.length > 0) {
+              body += `\n### Failed CI Steps\n${failedSteps.join('\n')}\n`;
+            }
+            body += `\n<!--buildkite-pr-comment-kibana-pull-request\n`;
+            body += JSON.stringify({
+              builds: [{
+                buildStatus: { state, success, hasRetries: false, hasNonPreemptionRetries: false },
+                url: buildUrl,
+                number: buildNumber,
+                commit
+              }],
+              number: buildNumber
+            });
+            body += `\nbuildkite-pr-comment-->\n`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100
+            });
+            const existing = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes('buildkite-pr-comment-kibana-pull-request')
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body
+              });
+            }


### PR DESCRIPTION
Layers three concerns onto the base CI fix loop from #21:

- **Local validation (M4.b):** `node scripts/check` as the pre-push gate with targeted re-run fallbacks and `kibana.jsonc`-based package discovery
- **Flake and bad-tests-on-main handling (M4.c):** distinguishes unrelated flakes and pre-existing failures from PR-related issues; neither counts against the retry budget
- **Escalation (M4.d):** progress-aware retry tracking — escalates after 3 repeated same-pattern failures or 10 total iterations, whichever comes first

Also bumps `timeout-minutes` from 45 to 60 to accommodate local validation runs.

Made with [Cursor](https://cursor.com)